### PR TITLE
Reword license and attribution information

### DIFF
--- a/_pages/coc.md
+++ b/_pages/coc.md
@@ -88,9 +88,8 @@ communications pertaining to community business.
 This Code of Conduct is distributed under a [Creative Commons
 Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/),
 derived from the [Open Source Bridge Code of
-Conduct](http://opensourcebridge.org/about/code-of-conduct/). The short version
-is taken from the [JSConf Code of
-Conduct](http://jsconf.com/codeofconduct.html).
+Conduct](http://opensourcebridge.org/about/code-of-conduct/) and the [JSConf
+Code of Conduct](http://jsconf.com/codeofconduct.html).
 
 *Version 1.0, adopted by StarCon on June 1, 2017.*
 


### PR DESCRIPTION
Previously, our coc had a "long" and "short" version, and the former was taken from the JS Code of conduct. We later changed it and took out the short version and I forgot to reword the attribution to JS Conf.